### PR TITLE
Set ctx->stored.plte bit field when reading PLTE chunk from disk

### DIFF
--- a/spng.c
+++ b/spng.c
@@ -1162,6 +1162,7 @@ static int read_chunks_before_idat(spng_ctx *ctx)
                 ctx->plte_offset = chunk.offset;
 
                 ctx->file.plte = 1;
+                ctx->stored.plte = 1;
             }
             else if(!memcmp(chunk.type, type_iend, 4)) return SPNG_ECHUNK_POS;
             else if(!memcmp(chunk.type, type_ihdr, 4)) return SPNG_ECHUNK_POS;


### PR DESCRIPTION
Without this bit field being set the color palette of an image read
from disk cannot be accessed.

Fixes #42 


I don't quite understand how the current test suite works, but let me know if/how you'd like a regression test added. I copied some code into `tests/test_spng.h` just as a sanity check but I doubt that it's something you'd want to keep around. (related to #5)

```c
    if (ihdr.color_type == SPNG_COLOR_TYPE_INDEXED) {
        struct spng_plte color_map;
        r=spng_get_plte(ctx, &color_map);
        if(r) {
            printf("%d - %s\n", r, spng_strerror(r));
            goto err;
        }
    }
```