### PR TITLE
Implement read format SPNG_FMT_RAW

### DIFF
--- a/docs/decode.md
+++ b/docs/decode.md
@@ -14,12 +14,21 @@ A read callback function should copy `length` bytes to `dest` and return 0 or
 ```c
 enum spng_format
 {
+    SPNG_FMT_RAW = 0,
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2
 };
 ```
+The `RGBA8` and `RGBA16` formats convert images of all color types to
+full RGBA format, scaling the bit depth if needed. Indexed color images
+are expanded by applying the look up table defined in the PLTE chunk.
+Additionally, images are deinterlaced if needed and 16 bit images are
+byte-swapped to host endianness.
 
-The channels are always in byte-order regardless of host endianness.
+The `RAW` format will deinterlace the image but otherwise leaves the
+data untransformed. 1, 2 and 4 bit depth data will remain in byte packed
+rows, chunks that modify image data (PLTE, tRANS, gAMA, etc.) are not
+applied and 16bit data is left in big endian byte order.
 
 # spng_decode_flags
 
@@ -76,6 +85,6 @@ Decodes the PNG file and writes the decoded image to `out`.
 `spng_decoded_image_size` with the same output format.
 
 Interlaced images are written deinterlaced to `out`,
-16-bit images are converted to host-endian.
+16-bit images are converted to host-endian (unless fmt == `SPNG_FMT_RAW`).
 
 This function can only be called once per context.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,9 @@ libspng can decode images to 8- or 16-bit RGBA formats from any PNG file,
 whether to use ancillary chunk information when decoding is controlled
 with `SPNG_DECODE_USE_*` flags, they're ignored by default.
 
+To ouput the image data untransformed (except for deinterlacing) use
+`SPNG_FMT_RAW` instead of `SPNG_FMT_RGBA[8|16]`
+
 ```c
 
 /* Create a context */

--- a/spng.c
+++ b/spng.c
@@ -1854,8 +1854,9 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
         pixel_size = 8;
     }
 
-    if(ctx->ihdr.color_type == SPNG_COLOR_TYPE_TRUECOLOR_ALPHA &&
-       ctx->ihdr.bit_depth == depth_target)
+    if((ctx->ihdr.color_type == SPNG_COLOR_TYPE_TRUECOLOR_ALPHA &&
+       ctx->ihdr.bit_depth == depth_target) ||
+       fmt == SPNG_FMT_RAW)
     {
         f.same_layout = 1;
         /*if(!flags && !f.interlaced) f.zerocopy = 1;*/
@@ -2540,7 +2541,7 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *out)
 
     /* define parameters used to calculate total uncompressed bytes */
     size_t bits_per_sample, nsamples;
-    if(fmt == SPNG_FMT_PNG)
+    if(fmt == SPNG_FMT_RAW)
     {
         switch ((enum spng_color_type)ctx->ihdr.color_type) {
             case SPNG_COLOR_TYPE_GRAYSCALE:

--- a/spng.c
+++ b/spng.c
@@ -2589,9 +2589,10 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *out)
         *out = row_bytes*ctx->ihdr.height + extra_bits/8 + (extra_bits%8 ? 1 : 0);
     }
     else {
-        size_t npixels = ctx->ihdr.width*ctx->ihdr.height;
         size_t bytes_per_sample = bits_per_sample / 8;
-        if (SIZE_MAX / ctx->ihdr.width < bytes_per_sample*nsamples) {
+        size_t npixels = ctx->ihdr.width;
+        npixels = npixels * ctx->ihdr.height;
+        if (SIZE_MAX / npixels < bytes_per_sample*nsamples) {
             return SPNG_EOVERFLOW;
         }
 

--- a/spng.c
+++ b/spng.c
@@ -2082,7 +2082,9 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
 
             if(ret) goto decode_err;
 
-            if(ctx->ihdr.bit_depth == 16) u16_row_to_host(scanline, scanline_width - 1);
+            if(ctx->ihdr.bit_depth == 16 && fmt != SPNG_FMT_RAW) {
+                u16_row_to_host(scanline, scanline_width - 1);
+            }
 
             ret = defilter_scanline(prev_scanline, scanline, scanline_width - 1, bytes_per_pixel, filter);
             if(ret) goto decode_err;

--- a/spng.c
+++ b/spng.c
@@ -5,10 +5,6 @@
 #include <string.h>
 #include <math.h>
 
-
-#include <stdio.h>
-
-
 #ifdef __FRAMAC__
     #define SPNG_DISABLE_OPT
     #include "tests/framac_stubs.h"
@@ -2325,12 +2321,12 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
                 {
                     unsigned char mask = ((1 << pixel_size_bits) - 1) << (8 - pixel_size_bits);
                     unsigned char val, *ptr = out;
-                    size_t row_offset = 0;
+                    size_t row_offset = 0, xoffset;
                     size_t row_bytes = (ctx->ihdr.width * pixel_size_bits + 7) >> 3;
                     for(k=0; k < width; k++, row_offset += pixel_size_bits) {
-                        size_t xoffset = (adam7_x_start[pass] + k * adam7_x_delta[pass]) * pixel_size_bits;
-                        size_t ioffset = ((adam7_y_start[pass] + scanline_idx * adam7_y_delta[pass]) *
-                                          row_bytes + (xoffset >> 3));
+                        xoffset = (adam7_x_start[pass] + k * adam7_x_delta[pass]) * pixel_size_bits;
+                        ioffset = ((adam7_y_start[pass] + scanline_idx * adam7_y_delta[pass]) *
+                                   row_bytes + (xoffset >> 3));
 
                         /* left shift off leading bits and extract out packed value */
                         val = *(row + row_offset / 8) << (row_offset % 8) & mask;
@@ -2628,11 +2624,11 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *out)
     }
     else {
         pixel_size = pixel_size >> 3;
-        *out = ctx->ihdr.width * ctx->ihdr.height;
-        if (SIZE_MAX / *out < pixel_size) {
+        *out = pixel_size * ctx->ihdr.width;
+        if (SIZE_MAX / *out < ctx->ihdr.height) {
             return SPNG_EOVERFLOW;
         }
-        *out *= pixel_size;
+        *out *= ctx->ihdr.height;
     }
 
     return 0;

--- a/spng.c
+++ b/spng.c
@@ -1782,6 +1782,8 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
 
     struct decode_flags f = {0};
 
+    if (fmt == SPNG_FMT_RAW && flags != 0) return SPNG_EFLAGS;
+
     ret = spng_decoded_image_size(ctx, fmt, &out_size_required);
     if(ret) return ret;
     if(out_size < out_size_required) return SPNG_EBUFSIZ;

--- a/spng.c
+++ b/spng.c
@@ -1789,7 +1789,6 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
     ret = spng_decoded_image_size(ctx, fmt, &out_size_required);
     if(ret) return ret;
     if(out_size < out_size_required) return SPNG_EBUFSIZ;
-    memset(out, 0, out_size_required);
 
     out_width = out_size_required / ctx->ihdr.height;
 
@@ -1868,6 +1867,13 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t out_size, int fm
     {
          depth_target = processing_depth;
          pixel_size_bits = (channels * depth_target);
+
+         /* Less than 8bit wide images are byte-packed which can cause
+         issues at the ends of rows and when deinterlacing if the memory
+         isn't all zeros */
+         if (processing_depth < 8) {
+             memset(out, 0, out_size_required);
+         }
     }
     /* pixel size can be 0 for less than 8bpp, special logic is
     used when deinterlacing images with pixel_size == 0 but this only

--- a/spng.c
+++ b/spng.c
@@ -2613,10 +2613,8 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *out)
     }
     else return SPNG_EFMT;
 
-    /* For grayscale data with bit depths less than 8 the total number of
-    bytes cannot exceed SIZE_MAX==2**64-1, even with an alpha channel */
     if (pixel_size < 8) {
-        if (SIZE_MAX / ctx->ihdr.width < ctx->ihdr.height) {
+        if (SIZE_MAX / ctx->ihdr.width / pixel_size < ctx->ihdr.height) {
             return SPNG_EOVERFLOW;
         }
         *out = (ctx->ihdr.width * pixel_size + 7) >> 3;

--- a/spng.h
+++ b/spng.h
@@ -122,9 +122,11 @@ enum spng_color_type
 
 enum spng_format
 {
-    SPNG_FMT_RAW = 0, /* Output data in the same format as on disk (after deinterlacing) */
     SPNG_FMT_RGBA8 = 1,
-    SPNG_FMT_RGBA16 = 2
+    SPNG_FMT_RGBA16 = 2,
+    /* SPNG_FMT_PNG = 4, TODO */
+    /* SPNG_FMT_BIG_ENDIAN = 8, TODO */
+    SPNG_FMT_RAW = (4 | 8), /* Output data in the same format as on disk */
 };
 
 enum spng_ctx_flags

--- a/spng.h
+++ b/spng.h
@@ -122,7 +122,7 @@ enum spng_color_type
 
 enum spng_format
 {
-    SPNG_FMT_PNG = 0, /* Output data in the same layout as on disk */
+    SPNG_FMT_RAW = 0, /* Output data in the same layout as on disk */
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2
 };

--- a/spng.h
+++ b/spng.h
@@ -122,7 +122,7 @@ enum spng_color_type
 
 enum spng_format
 {
-    SPNG_FMT_RAW = 0, /* Output data in the same layout as on disk */
+    SPNG_FMT_RAW = 0, /* Output data in the same format as on disk (after deinterlacing) */
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2
 };

--- a/spng.h
+++ b/spng.h
@@ -122,6 +122,7 @@ enum spng_color_type
 
 enum spng_format
 {
+    SPNG_FMT_PNG = 0, /* Output data in the same layout as on disk */
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2
 };

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -44,19 +44,20 @@ void gen_test_cases(struct spng_test_case *test_cases, int *test_cases_n)
        PNG format without calling functions that alias to png_set_expand(_16),
        which acts as if png_set_tRNS_to_alpha() was called, as a result
        there are no tests where transparency is not applied */
+    #define NCASES 5
+    int i, fmts_and_flags[2*NCASES] = {
+        SPNG_FMT_RAW, 0,
+        SPNG_FMT_RGBA8, SPNG_DECODE_TRNS,
+        SPNG_FMT_RGBA8, SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA,
+        SPNG_FMT_RGBA16, SPNG_DECODE_TRNS,
+        SPNG_FMT_RGBA16, SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA
 
-    test_cases[0].fmt = SPNG_FMT_RAW;
-    test_cases[0].flags = 0;
-    test_cases[1].fmt = SPNG_FMT_RGBA8;
-    test_cases[1].flags = SPNG_DECODE_TRNS;
-    test_cases[2].fmt = SPNG_FMT_RGBA8;
-    test_cases[2].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
-    test_cases[3].fmt = SPNG_FMT_RGBA16;
-    test_cases[3].flags = SPNG_DECODE_TRNS;
-    test_cases[4].fmt = SPNG_FMT_RGBA16;
-    test_cases[4].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
-
-    *test_cases_n = 5;
+    };
+    *test_cases_n = NCASES;
+    for (i = 0; i < NCASES; i++) {
+        test_cases[i].fmt = fmts_and_flags[2*i];
+        test_cases[i].flags = fmts_and_flags[2*i + 1];
+    }
 }
 
 

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -21,7 +21,8 @@ int info_printed = 0;
 void print_test_args(struct spng_test_case *test_case)
 {
     printf("Decode and compare ");
-    if(test_case->fmt == SPNG_FMT_RGBA8) printf("RGBA8, ");
+    if(test_case->fmt == SPNG_FMT_RAW) printf("RAW, ");
+    else if(test_case->fmt == SPNG_FMT_RGBA8) printf("RGBA8, ");
     else if(test_case->fmt == SPNG_FMT_RGBA16) printf("RGBA16, ");
 
     printf("FLAGS: ");
@@ -43,17 +44,19 @@ void gen_test_cases(struct spng_test_case *test_cases, int *test_cases_n)
        PNG format without calling functions that alias to png_set_expand(_16),
        which acts as if png_set_tRNS_to_alpha() was called, as a result
        there are no tests where transparency is not applied */
-    
-    test_cases[0].fmt = SPNG_FMT_RGBA8;
-    test_cases[0].flags = SPNG_DECODE_TRNS;
-    test_cases[1].fmt = SPNG_FMT_RGBA8;
-    test_cases[1].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
-    test_cases[2].fmt = SPNG_FMT_RGBA16;
-    test_cases[2].flags = SPNG_DECODE_TRNS;
-    test_cases[3].fmt = SPNG_FMT_RGBA16;
-    test_cases[3].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
 
-    *test_cases_n = 4;
+    test_cases[0].fmt = SPNG_FMT_RAW;
+    test_cases[0].flags = 0;
+    test_cases[1].fmt = SPNG_FMT_RGBA8;
+    test_cases[1].flags = SPNG_DECODE_TRNS;
+    test_cases[2].fmt = SPNG_FMT_RGBA8;
+    test_cases[2].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
+    test_cases[3].fmt = SPNG_FMT_RGBA16;
+    test_cases[3].flags = SPNG_DECODE_TRNS;
+    test_cases[4].fmt = SPNG_FMT_RGBA16;
+    test_cases[4].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
+
+    *test_cases_n = 5;
 }
 
 


### PR DESCRIPTION
Read the data "as is" from disk after decompression and deinterlacing. In this form when the pixel size is less than 8 bits rows will be byte-packed and multiple values will exist inside a single byte. 16bit data will be left in big endian format.

This output format will be compatible with the "zerocopy" flag for non-interlaced images when it is implemented.

Future work could include adding a flag that will retain the "on disk" format but upscale 1, 2 and 4 bits data to 8 bits and byte swap 16bit data if needed for ease of use (name TBD).

TODO:
- [x] Implement initial code support
- [x] Update testsuite code
- [x] Update docs

Fixes #24