### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/spng.c
+++ b/spng.c
@@ -2712,9 +2712,11 @@ static int buffer_read_fn(spng_ctx *ctx, void *user, void *data, size_t n)
 
 static int file_read_fn(spng_ctx *ctx, void *user, void *data, size_t n)
 {
-    if(fread(data, n, 1, user) != 1)
+    FILE *file = user;
+
+    if(fread(data, n, 1, file) != 1)
     {
-        if(feof(user)) return SPNG_IO_EOF;
+        if(feof(file)) return SPNG_IO_EOF;
         else return SPNG_IO_ERROR;
     }
 


### PR DESCRIPTION
```
../spng.c:2717:12: error: member reference base type 'void' is not a structure or union
        if(feof(user)) return SPNG_IO_EOF;
           ^~~~~~~~~~
/usr/include/stdio.h:497:35: note: expanded from macro 'feof'
 #define feof(p)         (!__isthreaded ? __sfeof(p) : (feof)(p))
                                         ^~~~~~~~~~
/usr/include/stdio.h:491:25: note: expanded from macro '__sfeof'
 #define __sfeof(p)      (((p)->_flags & __SEOF) != 0)
                          ~~~^ ~~~~~~
```