### PR TITLE
Implement spng fmt raw (new)

### DIFF
--- a/docs/decode.md
+++ b/docs/decode.md
@@ -17,7 +17,8 @@ enum spng_format
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
-    SPNG_FMT_PNG = 16
+    SPNG_FMT_PNG = 16,
+    SPNG_FMT_RAW = (SPNG_FMT_PNG | 32),
 };
 ```
 
@@ -39,12 +40,13 @@ enum spng_decode_flags
 # Supported format, flag combinations
 
 
-| PNG Format  | Output format     | Flags  | Notes                                     |
-|-------------|-------------------|--------|-------------------------------------------|
-| Any format* | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth |
-| Any format* | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth |
-| Any format* | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth |
-| Any format* | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian           |
+| PNG Format  | Output format     | Flags  | Notes                                       |
+|-------------|-------------------|--------|---------------------------------------------|
+| Any format* | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth   |
+| Any format* | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth   |
+| Any format* | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth   |
+| Any format* | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian             |
+| Any format* | `SPNG_FMT_RAW`    | None   | The PNG's format in big endian              |
 
 \* Any combination of color type and bit depth defined in the [standard](https://www.w3.org/TR/2003/REC-PNG-20031110/#table111).
 

--- a/docs/decode.md
+++ b/docs/decode.md
@@ -18,7 +18,7 @@ enum spng_format
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
     SPNG_FMT_PNG = 16,
-    SPNG_FMT_RAW = (SPNG_FMT_PNG | 32),
+    SPNG_FMT_RAW = 32
 };
 ```
 
@@ -46,7 +46,7 @@ enum spng_decode_flags
 | Any format* | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth   |
 | Any format* | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth   |
 | Any format* | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian             |
-| Any format* | `SPNG_FMT_RAW`    | None   | The PNG's format in big endian              |
+| Any format* | `SPNG_FMT_RAW`    | None   | The PNG's format in big-endian              |
 
 \* Any combination of color type and bit depth defined in the [standard](https://www.w3.org/TR/2003/REC-PNG-20031110/#table111).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,10 +1,9 @@
 # Basic usage
 
-libspng can decode images to 8- or 16-bit RGBA formats from any PNG file,
-whether to use ancillary chunk information when decoding is controlled
-with `SPNG_DECODE_USE_*` flags, they're ignored by default. To output the
-image data untransformed (except for deinterlacing) use `SPNG_FMT_RAW`,
-no flags can be used in "RAW" output format.
+libspng can decode images to an explicit output format (e.g. 8/16-bit RGBA)
+from any PNG format. With `SPNG_FMT_PNG` the pixel format will identical
+to the PNG's format in host-endian, or big-endian with `SPNG_FMT_RAW`,
+the latter does not support any transforms e.g. gamma correction.
 
 
 ```c

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,10 @@
 
 libspng can decode images to 8- or 16-bit RGBA formats from any PNG file,
 whether to use ancillary chunk information when decoding is controlled
-with `SPNG_DECODE_USE_*` flags, they're ignored by default.
+with `SPNG_DECODE_USE_*` flags, they're ignored by default. To output the
+image data untransformed (except for deinterlacing) use `SPNG_FMT_RAW`,
+no flags can be used in "RAW" output format.
+
 
 ```c
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -67,7 +67,8 @@ int main(int argc, char **argv)
     size_t out_size, out_width;
 
     /* Output format, does not depend on source PNG format except for
-       SPNG_FMT_PNG, which is the PNG's format in host-endian */
+       SPNG_FMT_PNG, which is the PNG's format in host-endian and SPNG_FMT_RAW
+       where the PNG's data is left in byte-packed or big endian format */
     int fmt = SPNG_FMT_PNG;
 
     /* For this format indexed color images are output as palette indices,
@@ -90,7 +91,7 @@ int main(int argc, char **argv)
     }
 
     /* ihdr.height will always be non-zero if spng_get_ihdr() succeeds */
-    out_width = out_size / ihdr.height; 
+    out_width = out_size / ihdr.height;
 
     struct spng_row_info row_info = {0};
 

--- a/examples/example.c
+++ b/examples/example.c
@@ -67,8 +67,9 @@ int main(int argc, char **argv)
     size_t out_size, out_width;
 
     /* Output format, does not depend on source PNG format except for
-       SPNG_FMT_PNG, which is the PNG's format in host-endian and SPNG_FMT_RAW
-       where the PNG's data is left in byte-packed or big endian format */
+       SPNG_FMT_PNG, which is the PNG's format in host-endian or
+       big-endian for SPNG_FMT_RAW.
+       Note that for these two formats <8-bit images are left byte-packed */
     int fmt = SPNG_FMT_PNG;
 
     /* For this format indexed color images are output as palette indices,

--- a/spng.c
+++ b/spng.c
@@ -230,7 +230,7 @@ struct spng_ctx
     z_stream zstream;
     unsigned char *scanline_buf, *prev_scanline_buf, *row_buf;
     unsigned char *scanline, *prev_scanline, *row;
-    
+
     size_t total_out_size;
     size_t out_width; /* total_out_size / ihdr.height */
 
@@ -466,7 +466,7 @@ static inline int read_data(spng_ctx *ctx, size_t bytes)
     if(!bytes) return 0;
 
     if(ctx->streaming && (bytes > SPNG_READ_SIZE)) return 1;
-    
+
     int ret;
     ret = ctx->read_fn(ctx, ctx->read_user_ptr, ctx->stream_buf, bytes);
     if(ret) return ret;
@@ -652,7 +652,7 @@ static int spng__inflate_stream(spng_ctx *ctx, char **out, size_t *len, uint32_t
 
             t = spng__realloc(ctx, buf, size);
             if(t == NULL) goto mem;
-            
+
             stream->avail_out = size / 2;
             stream->next_out = buf + size / 2;
         }
@@ -670,7 +670,7 @@ static int spng__inflate_stream(spng_ctx *ctx, char **out, size_t *len, uint32_t
         }
 
         ret = inflate(stream, Z_SYNC_FLUSH);
-        
+
     }while(ret != Z_STREAM_END);
 
     size = stream->total_out;
@@ -944,7 +944,7 @@ static inline void gamma_correct_row(unsigned char *row, uint32_t pixels, int fm
         for(i=0; i < pixels; i++)
         {
             px = row + i * 3;
-            
+
             px[0] = gamma_lut[px[0]];
             px[1] = gamma_lut[px[1]];
             px[2] = gamma_lut[px[2]];
@@ -1027,7 +1027,7 @@ static inline void scale_row(unsigned char *row, uint32_t pixels, int fmt, unsig
             px[0] = sample_to_target(px[0], depth, sbit->red_bits, 8);
             px[1] = sample_to_target(px[1], depth, sbit->green_bits, 8);
             px[2] = sample_to_target(px[2], depth, sbit->blue_bits, 8);
-            
+
             memcpy(row + i * 3, px, 3);
         }
     }
@@ -1374,7 +1374,7 @@ static int read_non_idat_chunks(spng_ctx *ctx)
     int prev_was_idat = ctx->state == SPNG_STATE_AFTER_IDAT ? 1 : 0;
     struct spng_chunk chunk;
     const unsigned char *data;
-    
+
     struct spng_chunk_bitfield stored;
     memcpy(&stored, &ctx->stored, sizeof(struct spng_chunk_bitfield));
 
@@ -1454,7 +1454,7 @@ static int read_non_idat_chunks(spng_ctx *ctx)
                     return ret;
                 }
                 else return SPNG_ECHUNK_POS;
-            } 
+            }
             else if(!memcmp(chunk.type, type_ihdr, 4)) return SPNG_ECHUNK_POS;
             else return SPNG_ECHUNK_UNKNOWN_CRITICAL;
         }
@@ -1726,7 +1726,7 @@ static int read_non_idat_chunks(spng_ctx *ctx)
                 if(chunk.length - keyword_len - 1) return SPNG_ECHUNK_SIZE;
 
                 if(ctx->data[keyword_len + 1] != 0) return SPNG_EICCP_COMPRESSION_METHOD;
-                
+
                 ctx->last_read_size = keyword_len;
                 ret = spng__inflate_stream(ctx, &ctx->iccp.profile, &ctx->iccp.profile_len, keyword_len + 1);
 
@@ -1742,7 +1742,7 @@ static int read_non_idat_chunks(spng_ctx *ctx)
 
             ret = read_chunk_bytes(ctx, chunk.length);
             if(ret) return ret;
-            
+
             data = ctx->data;
 
             if(!memcmp(chunk.type, type_splt, 4))
@@ -1880,10 +1880,10 @@ static int read_non_idat_chunks(spng_ctx *ctx)
                     memcpy(&ctx->exif, &exif, sizeof(struct spng_exif));
                     ctx->stored.exif = 1;
                 }
-                else return SPNG_EEXIF;    
+                else return SPNG_EEXIF;
             }
         }
-        
+
     }
 
     return ret;
@@ -1899,7 +1899,7 @@ static int read_chunks(spng_ctx *ctx, int only_ihdr)
         if(ctx->encode_only) return 0;
         else return 1;
     }
-    
+
     int ret = 0;
 
     if(ctx->state == SPNG_STATE_INPUT)
@@ -1953,13 +1953,13 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
     unsigned char *trns_px = ctx->trns_px;
     struct spng_sbit *sb = &ctx->decode_sb;
     struct spng_plte_entry16 *plte = ctx->decode_plte;
-    
+
     unsigned char *scanline = ctx->scanline;
 
     int pass = ri->pass;
     uint8_t next_filter = 0;
     size_t scanline_width = sub[pass].scanline_width;
-    uint32_t k; 
+    uint32_t k;
     uint32_t scanline_idx = ri->scanline_idx;
     uint32_t width = sub[pass].width;
     uint8_t r_8, g_8, b_8, a_8, gray_8;
@@ -1979,8 +1979,8 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
 
     if(fmt == SPNG_FMT_RGBA16) pixel_size = 8;
     else if(fmt == SPNG_FMT_RGB8) pixel_size = 3;
-    
-    if(fmt == SPNG_FMT_PNG)
+
+    if(fmt & SPNG_FMT_PNG)
     {
         if(len < (scanline_width - 1)) return SPNG_EBUFSIZ;
     }
@@ -1988,7 +1988,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
     {
         if(len < (width * pixel_size)) return SPNG_EBUFSIZ;
     }
-    
+
     if(scanline_idx == (sub[pass].height - 1) && ri->pass == ctx->last_pass)
     {
         ret = read_scanline_bytes(ctx, ctx->scanline, scanline_width - 1);
@@ -2010,7 +2010,10 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
         memset(ctx->prev_scanline, 0, scanline_width);
     }
 
-    if(ctx->ihdr.bit_depth == 16) u16_row_to_host(ctx->scanline, scanline_width - 1);
+    if(ctx->ihdr.bit_depth == 16 && ((fmt & SPNG_FMT_RAW) != SPNG_FMT_RAW)) {
+        /* RAW format keeps PNGs in big endian byteorder */
+        u16_row_to_host(ctx->scanline, scanline_width - 1);
+    }
 
     ret = defilter_scanline(ctx->prev_scanline, ctx->scanline, scanline_width, ctx->bytes_per_pixel, ri->filter);
     if(ret) return decode_err(ctx, ret);
@@ -2066,7 +2069,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
                     expand_row(out, scanline, plte, width, fmt);
                     break;
                 }
-                
+
                 memcpy(&entry, scanline + k, 1);
             }
             else /* < 8 */
@@ -2186,7 +2189,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
             memcpy(pixel, &r_8, 1);
             memcpy(pixel + 1, &g_8, 1);
             memcpy(pixel + 2, &b_8, 1);
-            
+
             if(fmt == SPNG_FMT_RGBA8) memcpy(pixel + 3, &a_8, 1);
         }
         else if(fmt == SPNG_FMT_RGBA16)
@@ -2222,7 +2225,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
         if(ri->pass == ctx->last_pass)
         {
             ctx->state = SPNG_STATE_EOI;
-            
+
             if(ctx->cur_chunk_bytes_left) /* zlib stream ended before an IDAT chunk boundary */
             {/* Discard the rest of the chunk */
                 int ret = discard_chunk_bytes(ctx, ctx->cur_chunk_bytes_left);
@@ -2247,7 +2250,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
     }
 
     if(f.interlaced) ri->row_num = adam7_y_start[ri->pass] + ri->scanline_idx * adam7_y_delta[ri->pass];
-    
+
     return 0;
 }
 
@@ -2259,7 +2262,7 @@ int spng_decode_row(spng_ctx *ctx, unsigned char *out, size_t len)
 
     int ret, pass = ctx->row_info.pass;
 
-    if(!ctx->ihdr.interlace_method || pass == 6) return spng_decode_scanline(ctx, out, len); 
+    if(!ctx->ihdr.interlace_method || pass == 6) return spng_decode_scanline(ctx, out, len);
 
     ret = spng_decode_scanline(ctx, ctx->row, ctx->out_width);
     if(ret && ret != SPNG_EOI) return ret;
@@ -2268,7 +2271,7 @@ int spng_decode_row(spng_ctx *ctx, unsigned char *out, size_t len)
     unsigned pixel_size = 4; /* RGBA8 */
     if(ctx->fmt == SPNG_FMT_RGBA16) pixel_size = 8;
     else if(ctx->fmt == SPNG_FMT_RGB8) pixel_size = 3;
-    else if(ctx->fmt == SPNG_FMT_PNG)
+    else if(ctx->fmt & SPNG_FMT_PNG)
     {
         if(ctx->ihdr.bit_depth < 8)
         {
@@ -2321,7 +2324,7 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t len, int fmt, in
 
     ret = read_chunks(ctx, 0);
     if(ret) return ret;
-    
+
     if( !(flags & SPNG_DECODE_PROGRESSIVE) )
     {
         if(out == NULL) return 1;
@@ -2395,7 +2398,7 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t len, int fmt, in
 
         f.apply_trns = 0; /* not applicable */
     }
-    else if(fmt == SPNG_FMT_PNG)
+    else if(fmt & SPNG_FMT_PNG)
     {
         f.same_layout = 1;
         f.do_scaling = 0;
@@ -2429,7 +2432,7 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t len, int fmt, in
 
             ctx->gamma_lut16 = spng__malloc(ctx, lut_entries * sizeof(uint16_t));
             if(ctx->gamma_lut16 == NULL) return decode_err(ctx, SPNG_EMEM);
-            
+
             gamma_lut = ctx->gamma_lut16;
             ctx->gamma_lut = ctx->gamma_lut16;
         }
@@ -2440,7 +2443,7 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t len, int fmt, in
         if(FP_ZERO == fpclassify(exponent)) return decode_err(ctx, SPNG_EGAMA);
 
         exponent = 1.0f / exponent;
-        
+
         int i;
         for(i=0; i < lut_entries; i++)
         {
@@ -2682,7 +2685,7 @@ void spng_ctx_free(spng_ctx *ctx)
     }
 
     inflateEnd(&ctx->zstream);
-    
+
     spng__free(ctx, ctx->gamma_lut16);
 
     spng__free(ctx, ctx->row_buf);
@@ -2766,9 +2769,9 @@ int spng_set_png_stream(spng_ctx *ctx, spng_read_fn *read_func, void *user)
 }
 
 int spng_set_png_file(spng_ctx *ctx, FILE *file)
-{  
+{
     if(file == NULL) return 1;
-    
+
     return spng_set_png_stream(ctx, file_read_fn, file);
 }
 
@@ -2853,7 +2856,7 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *len)
     {
         bytes_per_pixel = 3;
     }
-    else if(fmt == SPNG_FMT_PNG)
+    else if(fmt & SPNG_FMT_PNG)
     {
         struct spng_subimage img = {0};
         img.width = ctx->ihdr.width;

--- a/spng.c
+++ b/spng.c
@@ -1981,7 +1981,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
     if(fmt == SPNG_FMT_RGBA16) pixel_size = 8;
     else if(fmt == SPNG_FMT_RGB8) pixel_size = 3;
 
-    if(fmt & SPNG_FMT_PNG)
+    if(fmt & (SPNG_FMT_PNG | SPNG_FMT_RAW))
     {
         if(len < (scanline_width - 1)) return SPNG_EBUFSIZ;
     }
@@ -2011,10 +2011,7 @@ int spng_decode_scanline(spng_ctx *ctx, unsigned char *out, size_t len)
         memset(ctx->prev_scanline, 0, scanline_width);
     }
 
-    if(ctx->ihdr.bit_depth == 16 && ((fmt & SPNG_FMT_RAW) != SPNG_FMT_RAW)) {
-        /* RAW format keeps PNGs in big endian byteorder */
-        u16_row_to_host(ctx->scanline, scanline_width - 1);
-    }
+    if(ctx->ihdr.bit_depth == 16 && fmt != SPNG_FMT_RAW) u16_row_to_host(ctx->scanline, scanline_width - 1);
 
     ret = defilter_scanline(ctx->prev_scanline, ctx->scanline, scanline_width, ctx->bytes_per_pixel, ri->filter);
     if(ret) return decode_err(ctx, ret);
@@ -2272,7 +2269,7 @@ int spng_decode_row(spng_ctx *ctx, unsigned char *out, size_t len)
     unsigned pixel_size = 4; /* RGBA8 */
     if(ctx->fmt == SPNG_FMT_RGBA16) pixel_size = 8;
     else if(ctx->fmt == SPNG_FMT_RGB8) pixel_size = 3;
-    else if(ctx->fmt & SPNG_FMT_PNG)
+    else if(ctx->fmt & (SPNG_FMT_PNG | SPNG_FMT_RAW))
     {
         if(ctx->ihdr.bit_depth < 8)
         {
@@ -2399,7 +2396,7 @@ int spng_decode_image(spng_ctx *ctx, unsigned char *out, size_t len, int fmt, in
 
         f.apply_trns = 0; /* not applicable */
     }
-    else if(fmt & SPNG_FMT_PNG)
+    else if(fmt & (SPNG_FMT_PNG | SPNG_FMT_RAW))
     {
         f.same_layout = 1;
         f.do_scaling = 0;
@@ -2857,7 +2854,7 @@ int spng_decoded_image_size(spng_ctx *ctx, int fmt, size_t *len)
     {
         bytes_per_pixel = 3;
     }
-    else if(fmt & SPNG_FMT_PNG)
+    else if(fmt & (SPNG_FMT_PNG | SPNG_FMT_RAW))
     {
         struct spng_subimage img = {0};
         img.width = ctx->ihdr.width;

--- a/spng.h
+++ b/spng.h
@@ -144,7 +144,8 @@ enum spng_format
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
-    SPNG_FMT_PNG = 16
+    SPNG_FMT_PNG = 16,
+    SPNG_FMT_RAW = (32 | SPNG_FMT_PNG)
 };
 
 enum spng_ctx_flags

--- a/spng.h
+++ b/spng.h
@@ -145,7 +145,7 @@ enum spng_format
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
     SPNG_FMT_PNG = 16,
-    SPNG_FMT_RAW = (32 | SPNG_FMT_PNG)
+    SPNG_FMT_RAW = 32
 };
 
 enum spng_ctx_flags

--- a/tests/test_png.h
+++ b/tests/test_png.h
@@ -96,8 +96,8 @@ unsigned char *getimage_libpng(FILE *file, size_t *out_size, int fmt, int flags)
         png_set_strip_16(png_ptr);
     }
 
-#if defined(SPNG_LITTLE_ENDIAN) /* we want host-endian values unless RAW format */
-    if((fmt & SPNG_FMT_RAW) != SPNG_FMT_RAW) png_set_swap(png_ptr);
+#if defined(SPNG_LITTLE_ENDIAN) /* we want host-endian values unless it's SPNG_FMT_RAW */
+    if(fmt != SPNG_FMT_RAW) png_set_swap(png_ptr);
 #endif
 
     png_set_interlace_handling(png_ptr);

--- a/tests/test_png.h
+++ b/tests/test_png.h
@@ -92,12 +92,12 @@ unsigned char *getimage_libpng(FILE *file, size_t *out_size, int fmt, int flags)
         png_set_gray_to_rgb(png_ptr);
 
         png_set_strip_alpha(png_ptr);
-        
+
         png_set_strip_16(png_ptr);
     }
 
-#if defined(SPNG_LITTLE_ENDIAN) /* we want host-endian values */
-        png_set_swap(png_ptr);
+#if defined(SPNG_LITTLE_ENDIAN) /* we want host-endian values unless RAW format */
+    if((fmt & SPNG_FMT_RAW) != SPNG_FMT_RAW) png_set_swap(png_ptr);
 #endif
 
     png_set_interlace_handling(png_ptr);

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -19,6 +19,7 @@ void print_test_args(struct spng_test_case *test_case)
     else if(test_case->fmt == SPNG_FMT_RGBA16) printf("RGBA16, ");
     else if(test_case->fmt == SPNG_FMT_RGB8) printf("RGB8, ");
     else if(test_case->fmt == SPNG_FMT_PNG) printf("PNG, ");
+    else if(test_case->fmt == SPNG_FMT_RAW) printf("RAW, ");
 
     printf("FLAGS: ");
 
@@ -40,13 +41,13 @@ void gen_test_cases(struct spng_test_case *test_cases, int *test_cases_n)
     which acts as if png_set_tRNS_to_alpha() was called, as a result
     there are no tests where transparency is not applied
 */
-    
+
     int n=0;
 
     test_cases[n].fmt = SPNG_FMT_RGBA8;
     test_cases[n].flags = SPNG_DECODE_TRNS;
     test_cases[n++].test_flags = 0;
-    
+
     test_cases[n].fmt = SPNG_FMT_RGBA8;
     test_cases[n].flags = SPNG_DECODE_TRNS | SPNG_DECODE_GAMMA;
     test_cases[n++].test_flags = 0;
@@ -69,7 +70,11 @@ void gen_test_cases(struct spng_test_case *test_cases, int *test_cases_n)
 
     test_cases[n].fmt = SPNG_FMT_PNG;
     test_cases[n].flags = 0;
-    test_cases[n++].test_flags = 0;    
+    test_cases[n++].test_flags = 0;
+
+    test_cases[n].fmt = SPNG_FMT_RAW;
+    test_cases[n].flags = 0;
+    test_cases[n++].test_flags = 0;
 
     *test_cases_n = n;
 }
@@ -218,11 +223,11 @@ int compare_images(struct spng_ihdr *ihdr, int fmt, int flags, unsigned char *im
             }
             else if(fmt == SPNG_FMT_PNG)
             {
-                if(ihdr->bit_depth <= 8) /* gray 1-8, gray-alpha 8, indexed 1-8 */ 
+                if(ihdr->bit_depth <= 8) /* gray 1-8, gray-alpha 8, indexed 1-8 */
                 {
                     uint8_t s_alpha, s_sample;
                     uint8_t p_alpha, p_sample;
-                    
+
                     memcpy(&s_sample, img_spng + px_ofs, 1);
                     memcpy(&p_sample, img_png + px_ofs, 1);
 


### PR DESCRIPTION
Adds support for the `SPNG_FMT_RAW` flag and replaces the older PR #45 which was too out of sync with master to be worth updating.

Also I added `SPNG_FMT_RAW = (SPNG_FMT_PNG | 32)` that way we didn't need to add a bunch of extra logic branches into each format conditional and instead could just use bitwise `&`.

Fixes #24