### PR TITLE
initial UNPACK support

### DIFF
--- a/docs/decode.md
+++ b/docs/decode.md
@@ -40,13 +40,14 @@ enum spng_decode_flags
 # Supported format, flag combinations
 
 
-| PNG Format  | Output format     | Flags  | Notes                                       |
-|-------------|-------------------|--------|---------------------------------------------|
-| Any format* | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian             |
-| Any format* | `SPNG_FMT_RAW`    | None   | The PNG's format in big-endian              |
+| PNG Format  | Output format     | Flags  | Notes                                                        |
+|-------------|-------------------|--------|--------------------------------------------------------------|
+| Any format* | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth                    |
+| Any format  | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth                    |
+| Any format  | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth                    |
+| Any format  | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian                              |
+| Any format  | `SPNG_FMT_RAW`    | None   | The PNG's format in big-endian                               |
+| Any format  | `SPNG_FMT_UNPACK` | None** | The PNG's format in host-endian with <8-bit samples unpacked |
 
 \* Any combination of color type and bit depth defined in the [standard](https://www.w3.org/TR/2003/REC-PNG-20031110/#table111).
 

--- a/spng.h
+++ b/spng.h
@@ -145,7 +145,8 @@ enum spng_format
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
     SPNG_FMT_PNG = 16,
-    SPNG_FMT_RAW = 32
+    SPNG_FMT_RAW = 32,
+    SPNG_FMT_UNPACK = 64 /* Unpack <8-bit sample to bytes */
 };
 
 enum spng_ctx_flags

--- a/tests/test_png.h
+++ b/tests/test_png.h
@@ -95,6 +95,10 @@ unsigned char *getimage_libpng(FILE *file, size_t *out_size, int fmt, int flags)
 
         png_set_strip_16(png_ptr);
     }
+    else if(fmt == SPNG_FMT_UNPACK)
+    {
+        png_set_packing(png_ptr);
+    }
 
 #if defined(SPNG_LITTLE_ENDIAN) /* we want host-endian values unless it's SPNG_FMT_RAW */
     if(fmt != SPNG_FMT_RAW) png_set_swap(png_ptr);

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -20,6 +20,7 @@ void print_test_args(struct spng_test_case *test_case)
     else if(test_case->fmt == SPNG_FMT_RGB8) printf("RGB8, ");
     else if(test_case->fmt == SPNG_FMT_PNG) printf("PNG, ");
     else if(test_case->fmt == SPNG_FMT_RAW) printf("RAW, ");
+    else if(test_case->fmt == SPNG_FMT_UNPACK) printf("UNPACK, ");
 
     printf("FLAGS: ");
 
@@ -73,6 +74,10 @@ void gen_test_cases(struct spng_test_case *test_cases, int *test_cases_n)
     test_cases[n++].test_flags = 0;
 
     test_cases[n].fmt = SPNG_FMT_RAW;
+    test_cases[n].flags = 0;
+    test_cases[n++].test_flags = 0;
+
+    test_cases[n].fmt = SPNG_FMT_UNPACK;
     test_cases[n].flags = 0;
     test_cases[n++].test_flags = 0;
 


### PR DESCRIPTION
I haven't decided on the name yet, ideally all the formats would also be valid input formats later on for `spng_encode_image()`, in an encoding context `SPNG_FMT_PNG` would mean the image is encoded from host-endian with the color type and bit depth set with `spng_set_ihdr()`, if this new format was named `SPNG_FMT_PNG_UNPACKED` or `SPNG_FMT_PNG | SPNG_FMT_UNPACKED`, it could be interpreted as "what is described by IHDR but <8-bit samples should be packed to `IHDR.bit_depth` bit samples".

edit: `UNPACKED` instead of `UNPACK` so it makes sense for both decoding and encoding.

If this was going to be a flag it could be made to work with `RAW` too.

@stadelmanma 

fixes #74 


Sidenote: `png_set_expand_gray_1_2_4_to_8()` expands palette indices to 3 bytes (RGB more than likely), so a `SPNG_DECODE_EXPAND` flag would be the libpng equivalent of

```c
if(color_type == PNG_COLOR_TYPE_GRAY) png_set_expand_gray_1_2_4_to_8(png_ptr);
```
Also when ^this is added for this format in the testsuite compare_images is not printing the differing pixels.