### PR TITLE
Partial implementation for SPNG_FMT_G8

### DIFF
--- a/docs/decode.md
+++ b/docs/decode.md
@@ -39,14 +39,14 @@ enum spng_decode_flags
 
 # Supported format, flag combinations
 
-
-| PNG Format  | Output format     | Flags  | Notes                                       |
-|-------------|-------------------|--------|---------------------------------------------|
-| Any format* | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth   |
-| Any format* | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian             |
-| Any format* | `SPNG_FMT_RAW`    | None   | The PNG's format in big-endian              |
+| PNG Format   | Output format     | Flags  | Notes                                       |
+|--------------|-------------------|--------|---------------------------------------------|
+| Any format*  | `SPNG_FMT_RGBA8`  | All    | Convert from any PNG format and bit depth   |
+| Any format   | `SPNG_FMT_RGBA16` | All    | Convert from any PNG format and bit depth   |
+| Any format   | `SPNG_FMT_RGB8`   | All    | Convert from any PNG format and bit depth   |
+| Any format   | `SPNG_FMT_PNG`    | None** | The PNG's format in host-endian             |
+| Any format   | `SPNG_FMT_RAW`    | None   | The PNG's format in big-endian              |
+| Gray <=8-bit | `SPNG_FMT_G8`     | None** | Valid for 1, 2, 4, 8-bit grayscale only     |
 
 \* Any combination of color type and bit depth defined in the [standard](https://www.w3.org/TR/2003/REC-PNG-20031110/#table111).
 

--- a/spng.h
+++ b/spng.h
@@ -138,14 +138,19 @@ enum spng_interlace_method
     SPNG_INTERLACE_ADAM7 = 1
 };
 
-/* All formats are in host-endian, channels are in byte-order */
+/* Channels are always in byte-order */
 enum spng_format
 {
     SPNG_FMT_RGBA8 = 1,
     SPNG_FMT_RGBA16 = 2,
     SPNG_FMT_RGB8 = 4,
-    SPNG_FMT_PNG = 16,
-    SPNG_FMT_RAW = 32
+
+    /* Partially implemented, see documentation */
+    SPNG_FMT_G8 = 64,
+
+    /* No conversion or scaling */
+    SPNG_FMT_PNG = 256, /* host-endian */
+    SPNG_FMT_RAW = 512  /* big-endian */
 };
 
 enum spng_ctx_flags

--- a/tests/test_png.h
+++ b/tests/test_png.h
@@ -95,6 +95,10 @@ unsigned char *getimage_libpng(FILE *file, size_t *out_size, int fmt, int flags,
 
         png_set_strip_16(png_ptr);
     }
+    else if(fmt == SPNG_FMT_G8)
+    {/* TODO: support more input formats */
+        png_set_expand_gray_1_2_4_to_8(png_ptr);
+    }
     else if(fmt == SPNGT_FMT_VIPS)
     {
         png_set_palette_to_rgb(png_ptr);

--- a/tests/testsuite.c
+++ b/tests/testsuite.c
@@ -475,6 +475,7 @@ int main(int argc, char **argv)
     add_test_case(SPNG_FMT_RGB8, SPNG_DECODE_GAMMA, 0);
     add_test_case(SPNG_FMT_PNG, 0, 0);
     add_test_case(SPNG_FMT_RAW, 0, 0);
+    if(ihdr.color_type == SPNG_COLOR_TYPE_GRAYSCALE && ihdr.bit_depth <= 8) add_test_case(SPNG_FMT_G8, 0, 0);
 
     int ret = 0;
     uint32_t i;


### PR DESCRIPTION
This implements `png_set_expand_gray_1_2_4_to_8()` for grayscale 1/2/4/8-bit PNG's (#85), conversion from other formats will be shipped as bugfixes later.
