### PR TITLE
fuzz: read time chunk after decoding the image

### DIFF
--- a/tests/ossfuzz.sh
+++ b/tests/ossfuzz.sh
@@ -3,16 +3,19 @@
 # This script is meant to be run by
 # https://github.com/google/oss-fuzz/blob/master/projects/libspng/Dockerfile
 
-mkdir $SRC/libspng/zlib/build $SRC/libspng/build
-cd $SRC/libspng/zlib/build
+tar xzvf $WORK/zlib.tar.gz --directory $SRC/
+mv $SRC/zlib-1.2.11 $SRC/zlib
+
+mkdir $SRC/zlib/build $SRC/libspng/build
+cd $SRC/zlib/build
 cmake ..
 make -j$(nproc)
 
-$CC $CFLAGS -c -I$SRC/libspng/zlib/build -I$SRC/libspng/zlib \
+$CC $CFLAGS -c -I$SRC/zlib/build -I$SRC/zlib \
     $SRC/libspng/spng/spng.c \
     -o $SRC/libspng/build/libspng.o \
 
-cp $SRC/libspng/zlib/build/libz.a $SRC/libspng/build/libz.a
+cp $SRC/zlib/build/libz.a $SRC/libspng/build/libz.a
 cd $SRC/libspng/build
 ar x libz.a
 ar rcs libspng_static.a *.o
@@ -20,14 +23,14 @@ ar rcs libspng_static.a *.o
 $CXX $CXXFLAGS -std=c++11 \
     $SRC/libspng/tests/spng_read_fuzzer.cc \
     -o $OUT/spng_read_fuzzer \
-    $LIB_FUZZING_ENGINE $SRC/libspng/build/libspng_static.a $SRC/libspng/zlib/build/libz.a
+    $LIB_FUZZING_ENGINE $SRC/libspng/build/libspng_static.a $SRC/zlib/build/libz.a
 
-$CXX $CXXFLAGS -std=c++11 -I$SRC/libspng/zlib/build -I$SRC/libspng/zlib \
+$CXX $CXXFLAGS -std=c++11 -I$SRC/zlib/build -I$SRC/zlib \
     $SRC/libspng/tests/spng_read_fuzzer.cc \
     -o $OUT/spng_read_fuzzer_structure_aware \
     -include $SRC/fuzzer-test-suite/libpng-1.2.56/png_mutator.h \
     -D PNG_MUTATOR_DEFINE_LIBFUZZER_CUSTOM_MUTATOR \
-    $LIB_FUZZING_ENGINE $SRC/libspng/build/libspng_static.a $SRC/libspng/zlib/build/libz.a
+    $LIB_FUZZING_ENGINE $SRC/libspng/build/libspng_static.a $SRC/zlib/build/libz.a
 
 find $SRC/libspng/tests/images -name "*.png" | \
      xargs zip $OUT/spng_read_fuzzer_seed_corpus.zip

--- a/tests/spng_read_fuzzer.cc
+++ b/tests/spng_read_fuzzer.cc
@@ -128,7 +128,6 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     spng_get_hist(ctx, &hist);
     spng_get_phys(ctx, &phys);
     spng_get_splt(ctx, splt, &n_splt);
-    spng_get_time(ctx, &time);
 
     if(progressive)
     {
@@ -146,6 +145,8 @@ int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         }while(!spng_decode_row(ctx, out + ioffset, out_size));
     }
     else if(spng_decode_image(ctx, out, out_size, fmt, flags)) goto err;
+
+    spng_get_time(ctx, &time);
 
 err:
     spng_ctx_free(ctx);


### PR DESCRIPTION
PNG's are not read up the the IEND marker unless a spng_get_*() call triggers it