### PR TITLE
Demote `inflateValidate` warning to a message

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -371,11 +371,7 @@ static int spng__inflate_init(spng_ctx *ctx)
 #if ZLIB_VERNUM >= 0x1290 && !defined(SPNG_USE_MINIZ)
     if(inflateValidate(&ctx->zstream, ctx->flags & SPNG_CTX_IGNORE_ADLER32)) return SPNG_EZLIB;
 #else /* This requires zlib >= 1.2.11 */
-#ifdef _MSC_VER
     #pragma message ("inflateValidate() not available, SPNG_CTX_IGNORE_ADLER32 will be ignored")
-#else
-    #warning "inflateValidate() not available, SPNG_CTX_IGNORE_ADLER32 will be ignored"
-#endif
 #endif
 
     return 0;


### PR DESCRIPTION
A warning halts builds with a `-Werror` flag, but there is nothing to resolve when using miniz.