### PR TITLE
Replace fmin with comparison

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -2962,7 +2962,7 @@ int spng_decode_image(spng_ctx *ctx, void *out, size_t len, int fmt, int flags)
         for(i=0; i < lut_entries; i++)
         {
             float c = pow((float)i / max, exponent) * max;
-            c = fmin(c, max);
+            if(c > max) c = max;
 
             gamma_lut[i] = (uint16_t)c;
         }


### PR DESCRIPTION
Strangely, DJGPP (DOS port of GCC) does not provide fmin.
