### PR TITLE
make SPNG_CRC_USE also ignore adler32 checksums

### DIFF
--- a/spng/spng.h
+++ b/spng/spng.h
@@ -176,11 +176,12 @@ enum spng_crc_action
     /* Default for critical chunks */
     SPNG_CRC_ERROR = 0,
 
-    /* Discard chunk, invalid for critical chunks,
-       since v0.6.2: default for ancillary chunks */
+    /* Discard chunk, invalid for critical chunks.
+       Since v0.6.2: default for ancillary chunks */
     SPNG_CRC_DISCARD = 1,
 
-    /* Ignore and don't calculate checksum */
+    /* Ignore and don't calculate checksum.
+       Since v0.6.2: also ignores checksums in DEFLATE streams */
     SPNG_CRC_USE = 2
 };
 


### PR DESCRIPTION
Brings adler32 checksum handling more in line with libpng: https://github.com/glennrp/libpng/blob/v1.6.37/libpng-manual.txt#L471

Maybe it should just have the effect of `SPNG_CTX_IGNORE_ADLER32` when it's set for either chunk type, but it's hard to figure out what libpng is doing.