### PR TITLE
improve error reporting with more error codes

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -862,7 +862,7 @@ static int spng__inflate_stream(spng_ctx *ctx, char **out, size_t *len, size_t e
 
     buf = t;
 
-    increase_cache_usage(ctx, size);
+    (void)increase_cache_usage(ctx, size);
 
     *out = buf;
     *len = size;
@@ -873,9 +873,7 @@ mem:
     ret = SPNG_EMEM;
 err:
     spng__free(ctx, buf);
-    if(ret) return ret;
-
-    return SPNG_EMEM;
+    return ret;
 }
 
 /* Read at least one byte from the IDAT stream */

--- a/spng/spng.h
+++ b/spng/spng.h
@@ -105,6 +105,8 @@ enum spng_errno
     SPNG_ENCODE_ONLY,
     SPNG_EOI,
     SPNG_ENOPLTE,
+    SPNG_ECHUNK_LIMITS,
+    SPNG_EZLIB_INIT,
 };
 
 enum spng_text_type


### PR DESCRIPTION
use SPNG_ECHUNK_LIMITS instead of SPNG_EMEM when chunk limits are reached
spng__inflate_init(): return SPNG_EZLIB_INIT instead of SPNG_EZLIB on error
increase_cache_usage(): use proper error codes