### PR TITLE
discard invalid length bKGD chunks for color type 2, 6

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -1907,8 +1907,7 @@ static int read_non_idat_chunks(spng_ctx *ctx)
                 if(chunk.length != 6)
                 {
                     if(ctx->strict) return SPNG_ECHUNK_SIZE;
-                    discard = 1;
-                    goto discard;
+                    else continue;
                 }
 
                 ctx->bkgd.red = read_u16(data) & mask;

--- a/spng/spng.c
+++ b/spng/spng.c
@@ -1904,7 +1904,12 @@ static int read_non_idat_chunks(spng_ctx *ctx)
             }
             else if(ctx->ihdr.color_type == 2 || ctx->ihdr.color_type == 6)
             {
-                if(chunk.length != 6) return SPNG_ECHUNK_SIZE;
+                if(chunk.length != 6)
+                {
+                    if(ctx->strict) return SPNG_ECHUNK_SIZE;
+                    discard = 1;
+                    goto discard;
+                }
 
                 ctx->bkgd.red = read_u16(data) & mask;
                 ctx->bkgd.green = read_u16(data + 2) & mask;


### PR DESCRIPTION
another stopgap measure before a more general solution is implemented
(https://github.com/randy408/libspng/issues/132)