### PR TITLE
Add flip vertical feature on decode

### DIFF
--- a/docs/decode.md
+++ b/docs/decode.md
@@ -40,6 +40,7 @@ enum spng_decode_flags
 
     SPNG_DECODE_TRNS = 1, /* Apply transparency */
     SPNG_DECODE_GAMMA = 2, /* Apply gamma correction */
+    SPNG_DECODE_FLIP_Y = 16, /* Flip the image vertically */
     SPNG_DECODE_PROGRESSIVE = 256 /* Initialize for progressive reads */
 };
 ```

--- a/spng/spng.c
+++ b/spng/spng.c
@@ -3216,6 +3216,11 @@ int spng_decode_image(spng_ctx *ctx, void *out, size_t len, int fmt, int flags)
     {
         size_t ioffset = ri->row_num * ctx->out_width;
 
+        if(flags & SPNG_DECODE_FLIP_Y)
+        {
+            ioffset = len - ctx->out_width - ioffset;
+        }
+
         ret = spng_decode_row(ctx, (unsigned char*)out + ioffset, ctx->out_width);
     }while(!ret);
 

--- a/spng/spng.h
+++ b/spng/spng.h
@@ -172,6 +172,7 @@ enum spng_decode_flags
 
     SPNG_DECODE_TRNS = 1, /* Apply transparency */
     SPNG_DECODE_GAMMA = 2, /* Apply gamma correction */
+    SPNG_DECODE_FLIP_Y = 16, /* Flip the image vertically */
     SPNG_DECODE_PROGRESSIVE = 256 /* Initialize for progressive reads */
 };
 


### PR DESCRIPTION
#129 

This PR adds a vertical image flip option on decode with SPNG_DECODE_FLIP_Y, and adds it to the documentation.

I did some OpenGL image loading to check if it worked
![upside_down](https://user-images.githubusercontent.com/39204944/116820159-25c3b300-ab39-11eb-9b02-43596bca8259.png)
(decoded with no flags)
![flipped](https://user-images.githubusercontent.com/39204944/116820170-307e4800-ab39-11eb-8d42-d1643a8cd277.png)
(decoded with SPNG_DECODE_FLIP_Y)
