### PR TITLE
Added option to flip image on encode

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -4863,7 +4863,11 @@ int spng_encode_image(spng_ctx *ctx, const void *img, size_t len, int fmt, int f
 
     do
     {
-        size_t ioffset = ri->row_num * ctx->image_width;
+        size_t ioffset;
+        if ( flags & SPNG_ENCODE_FLIP_Y )
+            ioffset = ( ihdr->height - ri->row_num - 1 ) * ctx->image_width;
+        else
+            ioffset = ri->row_num * ctx->image_width;
 
         ret = encode_row(ctx, (unsigned char*)img + ioffset, ctx->image_width);
 

--- a/spng/spng.h
+++ b/spng/spng.h
@@ -216,6 +216,7 @@ enum spng_encode_flags
 {
     SPNG_ENCODE_PROGRESSIVE = 1, /* Initialize for progressive writes */
     SPNG_ENCODE_FINALIZE = 2, /* Finalize PNG after encoding image */
+    SPNG_ENCODE_FLIP_Y = 4, /* Flip image vertically */
 };
 
 struct spng_ihdr


### PR DESCRIPTION
This is adding an option to flip the image vertically upon encoding.
I do not understand the structure of the code, but the modifications are local to spng_encode_image(), and they work for me. All the best! 