### PR TITLE
Fixed doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ spng_set_option(enc, SPNG_ENCODE_TO_BUFFER, 1);
 /* Specify image dimensions, PNG format */
 struct spng_ihdr ihdr =
 {
-    .height = height,
     .width = width,
+    .height = height,
     .bit_depth = 8,
     .color_type = SPNG_COLOR_TYPE_TRUECOLOR_ALPHA
 };

--- a/spng/spng.c
+++ b/spng/spng.c
@@ -4863,7 +4863,11 @@ int spng_encode_image(spng_ctx *ctx, const void *img, size_t len, int fmt, int f
 
     do
     {
-        size_t ioffset = ri->row_num * ctx->image_width;
+        size_t ioffset;
+        if ( flags & SPNG_ENCODE_FLIP_Y )
+            ioffset = ( ihdr->height - ri->row_num - 1 ) * ctx->image_width;
+        else
+            ioffset = ri->row_num * ctx->image_width;
 
         ret = encode_row(ctx, (unsigned char*)img + ioffset, ctx->image_width);
 

--- a/spng/spng.h
+++ b/spng/spng.h
@@ -216,6 +216,7 @@ enum spng_encode_flags
 {
     SPNG_ENCODE_PROGRESSIVE = 1, /* Initialize for progressive writes */
     SPNG_ENCODE_FINALIZE = 2, /* Finalize PNG after encoding image */
+    SPNG_ENCODE_FLIP_Y = 4, /* Flip image vertically */
 };
 
 struct spng_ihdr


### PR DESCRIPTION
I had copy-pasted the code on the README.md and it gave me an error.
Older C language versions require struct members to be initialized in the order in which they are declared.
This is the fix.