### PR TITLE
cmake: make finding zlib in-tree easier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ option(BUILD_EXAMPLES "Build examples" ON)
 
 include(GNUInstallDirs)
 
+# Allow the usage of [PackageName]_ROOT variables for FindPackage
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 find_package(ZLIB REQUIRED)
 include_directories(${ZLIB_INCLUDE_DIRS})
 


### PR DESCRIPTION
When building libspng as a sub-module alongside zlib as a sub-module,
then it becomes much easier to locate the in-tree zlib when the
ZLIB_ROOT variable can be set to ${zlib_BINARY_DIR}.  This is especially
useful when building on Windows where zlib-dev typically isn't
installed.

Setting the policy opts in to the NEW behaviour, which allows the use of the [PackageName]_ROOT variable.