### PR TITLE
Fixed build warnings

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -4999,11 +4999,11 @@ void spng_ctx_free(spng_ctx *ctx)
     spng__free(ctx, ctx->prev_scanline_buf);
     spng__free(ctx, ctx->filtered_scanline_buf);
 
-    spng_free_fn *free_func = ctx->alloc.free_fn;
+    spng_free_fn *free_fn = ctx->alloc.free_fn;
 
     memset(ctx, 0, sizeof(spng_ctx));
 
-    free_func(ctx);
+    free_fn(ctx);
 }
 
 static int buffer_read_fn(spng_ctx *ctx, void *user, void *data, size_t n)


### PR DESCRIPTION
Fixes warnings:
```
deps/libspng/spng/spng.c: In function ‘spng_ctx_free’:
deps/libspng/spng/spng.c:5002:19: warning: declaration of ‘free_func’ shadows a global declaration [-Wshadow]
 5002 |     spng_free_fn *free_func = ctx->alloc.free_fn;
      |                   ^~~~~~~~~
In file included from deps/libspng/spng/spng.c:21:
deps/zlib/zlib.h:82:18: note: shadowed declaration is here
   82 | typedef void   (*free_func)  OF((voidpf opaque, voidpf address));
      |    
```