### PR TITLE
build(meson): remove explicit pkgconf Libs.private

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,5 @@ pkg = import('pkgconfig')
 
 pkg.generate(spng_lib,
     extra_cflags : spng_args,
-    libraries_private : [ '-lm', '-lz' ],
     description : 'PNG decoding and encoding library'
 )


### PR DESCRIPTION
Meson automatically extracts the required dependencies of the library passed to `pkg.generate()`, so there's no need to list them explicitly.

This also removes the unneeded `-lz` from `Libs.private` when `Requires.private` already specifies `zlib`.