### PR TITLE
CMake: Add config-file package support, add static library pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.12)
 
 project(libspng C)
 
@@ -15,58 +15,94 @@ option(SPNG_STATIC "Build static lib" ON)
 option(BUILD_EXAMPLES "Build examples" ON)
 
 include(GNUInstallDirs)
-
-# Allow the usage of [PackageName]_ROOT variables for FindPackage
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
-    cmake_policy(SET CMP0074 NEW)
-endif()
-
-find_package(ZLIB REQUIRED)
-include_directories(${ZLIB_INCLUDE_DIRS})
-
-set(spng_SOURCES spng/spng.c)
+include(CMakePackageConfigHelpers)
 
 if(NOT CMAKE_HOST_WIN32)
-    set(spng_LIBS -lm ${ZLIB_LIBRARIES})
+    set(MATH_LIBRARY "m")
 else()
-    set(spng_LIBS ${ZLIB_LIBRARIES})
+    set(MATH_LIBRARY "")
 endif()
 
 if(NOT ENABLE_OPT)
     add_definitions( -DSPNG_DISABLE_OPT=1 )
 endif()
 
+set(spng_TARGETS "")
+
+set(spng_SOURCES spng/spng.c)
+
 if(SPNG_SHARED)
     add_library(spng SHARED ${spng_SOURCES})
-    target_include_directories(spng PUBLIC ${PROJECT_SOURCE_DIR}/spng)
-    target_link_libraries(spng ${spng_LIBS})
-    install(TARGETS spng DESTINATION lib)
+    list(APPEND spng_TARGETS spng)
 
     if(BUILD_EXAMPLES)
         add_executable(example examples/example.c)
-        target_include_directories(example PRIVATE ${PROJECT_SOURCE_DIR}/spng)
-        target_link_libraries(example spng ${spng_LIBS})
+        target_link_libraries(example PRIVATE spng)
     endif()
 endif()
 
 if(SPNG_STATIC)
     add_library(spng_static STATIC ${spng_SOURCES})
-    target_include_directories(spng_static PUBLIC ${PROJECT_SOURCE_DIR}/spng)
     target_compile_definitions(spng_static PUBLIC SPNG_STATIC)
-    install(TARGETS spng_static DESTINATION lib)
+    list(APPEND spng_TARGETS spng_static)
 endif()
 
-install(FILES spng/spng.h DESTINATION include)
+find_package(ZLIB REQUIRED)
+foreach(spng_TARGET ${spng_TARGETS})
+    target_include_directories(${spng_TARGET} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spng>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+    target_link_libraries(${spng_TARGET} PRIVATE ZLIB::ZLIB)
+    target_link_libraries(${spng_TARGET} PRIVATE ${MATH_LIBRARY})
+endforeach()
 
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/SPNGConfig.cmake")
+set(project_version_config "${CMAKE_CURRENT_BINARY_DIR}/SPNGConfigVersion.cmake")
+set(targets_export_name SPNGTargets)
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/spng")
+
+configure_package_config_file(cmake/Config.cmake.in ${project_config}
+  INSTALL_DESTINATION ${config_install_dir}
+)
+
+write_basic_package_version_file(${project_version_config}
+  VERSION ${SPNG_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  TARGETS ${spng_TARGETS}
+  EXPORT ${targets_export_name}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES spng/spng.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(
+  FILES ${project_config} ${project_version_config}
+  DESTINATION ${config_install_dir}
+)
+
+install(
+  EXPORT ${targets_export_name}
+  NAMESPACE "spng::"
+  DESTINATION ${config_install_dir}
+)
 
 if(NOT CMAKE_HOST_WIN32 OR CYGWIN OR MINGW)
     set(prefix      ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix ${CMAKE_INSTALL_PREFIX})
     set(libdir      ${CMAKE_INSTALL_FULL_LIBDIR})
     set(includedir  ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-    set(LIBS        "-lz -lm")
+    set(LIBS        "-lm")
 
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tests/libspng.pc.in ${CMAKE_CURRENT_BINARY_DIR}/tests/libspng.pc @ONLY)
+    foreach(libname ${spng_TARGETS})
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/libspng.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc @ONLY)
 
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tests/libspng.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+    endforeach()
 endif()

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+find_dependency(ZLIB REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+
+check_required_components(spng)

--- a/cmake/libspng.pc.in
+++ b/cmake/libspng.pc.in
@@ -3,10 +3,10 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@/
 
-Name: libspng
+Name: lib@libname@
 Description: PNG decoding and encoding library
 Version: @SPNG_VERSION@
 Requires: zlib
-Libs: -L${libdir} -lspng
+Libs: -L${libdir} -l@libname@
 Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
With these changes, libpng can be used in CMake projects by using the `find_package` mechanism as follows:
```cmake
find_package(spng)
target_link_libraries(<Target> PRIVATE spng::spng)
target_link_libraries(<Target> PRIVATE spng::spng_static)
```

Also adds generation of the equivalent pkg-config file for the static library