### PR TITLE
meson: try to fix compilation with clang-cl

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ elif cc.get_argument_syntax() == 'gcc' and host_machine.system() == 'x86'
 endif
 
 # Check for GNU target_clones attribute
-if cc.compiles(files('tests/target_clones.c'), args : '-Werror', name : 'have target_clones')
+if cc.links(files('tests/target_clones.c'), args : '-Werror', name : 'have target_clones')
     add_project_arguments('-DSPNG_ENABLE_TARGET_CLONES', language : 'c')
 endif
 


### PR DESCRIPTION
with clang-cl, compilation fails with an undefined reference to __cpu_indicator_init

Online search indicates this is related to target_clones.

Try linking to make sure this actually works.