### PR TITLE
Fix finding libspng with CMake

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,7 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
 find_dependency(ZLIB REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
The macro should be included before usage, this include is not auto-generated by @PACKAGE_INIT@