### PR TITLE
Fix installed cmake config file

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
 find_dependency(ZLIB REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
Currently, when use `find_package(SPNG CONFIG REQUIRED)` , an error occurred.
```
CMake Error at vcpkg/installed/x64-windows/share/spng/SPNGConfig.cmake:27 (find_dependency):
  Unknown CMake command "find_dependency".
```

Reference: https://github.com/microsoft/vcpkg/pull/35412