### PR TITLE
Added missing include in CMake config

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
 find_dependency(ZLIB REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
Missing include leads to error:
```
$ cmake -DSPNG_DIR=/home/alexander/Projects/libspng-0.7.4/build/install/lib/cmake/spng/ ../src/
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /home/alexander/Projects/libspng-0.7.4/build/install/lib/cmake/spng/SPNGConfig.cmake:27 (find_dependency):
  Unknown CMake command "find_dependency".
Call Stack (most recent call first):
  CMakeLists.txt:5 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/alexander/tmp/opencv-repro/build/CMakeFiles/CMakeOutput.log".
```