### PR TITLE
CMake improvements when vendoring with FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,10 @@ if(SPNG_STATIC)
     list(APPEND spng_TARGETS spng_static)
 endif()
 
-find_package(ZLIB REQUIRED)
+if(NOT TARGET ZLIB::ZLIB)
+    find_package(ZLIB REQUIRED)
+endif()
+
 foreach(spng_TARGET ${spng_TARGETS})
     target_include_directories(${spng_TARGET} PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/spng>
@@ -71,38 +74,42 @@ write_basic_package_version_file(${project_version_config}
   COMPATIBILITY SameMajorVersion
 )
 
-install(
-  TARGETS ${spng_TARGETS}
-  EXPORT ${targets_export_name}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
+    install(FILES spng/spng.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()
 
-install(FILES spng/spng.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+    install(
+      TARGETS ${spng_TARGETS}
+      EXPORT ${targets_export_name}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
-install(
-  FILES ${project_config} ${project_version_config}
-  DESTINATION ${config_install_dir}
-)
+    install(
+      FILES ${project_config} ${project_version_config}
+      DESTINATION ${config_install_dir}
+    )
 
-install(
-  EXPORT ${targets_export_name}
-  NAMESPACE "spng::"
-  DESTINATION ${config_install_dir}
-)
+    install(
+      EXPORT ${targets_export_name}
+      NAMESPACE "spng::"
+      DESTINATION ${config_install_dir}
+    )
 
-if(NOT CMAKE_HOST_WIN32 OR CYGWIN OR MINGW)
-    set(prefix      ${CMAKE_INSTALL_PREFIX})
-    set(exec_prefix ${CMAKE_INSTALL_PREFIX})
-    set(libdir      ${CMAKE_INSTALL_FULL_LIBDIR})
-    set(includedir  ${CMAKE_INSTALL_FULL_INCLUDEDIR})
-    set(LIBS        "-lm")
+    if(NOT CMAKE_HOST_WIN32 OR CYGWIN OR MINGW)
+        set(prefix      ${CMAKE_INSTALL_PREFIX})
+        set(exec_prefix ${CMAKE_INSTALL_PREFIX})
+        set(libdir      ${CMAKE_INSTALL_FULL_LIBDIR})
+        set(includedir  ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+        set(LIBS        "-lm")
 
-    foreach(libname ${spng_TARGETS})
-        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/libspng.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc @ONLY)
+        foreach(libname ${spng_TARGETS})
+            configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/libspng.pc.in ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc @ONLY)
 
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-    endforeach()
+            install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/lib${libname}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+        endforeach()
+    endif()
 endif()


### PR DESCRIPTION
This patch makes the following improvements to the CMake configuration:

- If the target ZLIB::ZLIB already exists, find_package for zlib is not called: this is advantageous if the project that is vendoring libspng is also vendoring zlib, or has an alternate zlib implementation (like zlib-ng.) Otherwise, ugly hacks are needed to make the find_package a no-op (e.g.: introducing a FindZLIB.cmake module somewhere earlier in the search path that does this check and then calls the root module.)

- It will now honor the `SKIP_INSTALL_ALL`, `SKIP_INSTALL_HEADERS`, and `SKIP_INSTALL_LIBRARIES` variables when setting up `install` targets. This is useful because zlib also honors this setting, and there's not much sense in installing libspng if it depends on vendored zlib which is not going to have install targets. (It causes an error, too.)

This should be fairly safe: when configuring standalone, this shouldn't change any of the existing behavior. For vendoring with `FetchContent`, I reckon this still shouldn't break any of the existing cases. This can help on Windows for a project that aims to compile out-of-the-box using Visual Studio without needing tooling like vcpkg, as zlib isn't present by default in this environment.

Fixes #266.

P.S.: Thanks for your work, by the way! libspng is a breath of fresh air.