### PR TITLE
Bazel: Define a minimal Bazel module

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,17 @@
+# This rule produces lib${name}.so and lib${name}.a
+cc_library(
+    name = "spng",
+    srcs = ["spng/spng.c"],
+    hdrs = ["spng/spng.h"],
+    includes = ["spng"],
+    visibility = ["//visibility:public"],
+    deps = ["@zlib"],
+)
+
+# This alias allows one to simply use "@libspng" as dependency,
+# instead of "@libsnpg//:spng".
+alias(
+    name = "libspng",
+    actual = ":spng",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,11 @@
+"""
+PNG decoding and encoding library
+"""
+
+module(
+    name = "libspng",
+    version = "0.7.4",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "zlib", version = "1.3.1")


### PR DESCRIPTION
This defines the very minimal integration with Bazel build system. The definitions follow the spirit of README.md in that the build rules package the library such that it can be included with

```c
#include <spng.h>
```