### PR TITLE
Add option to invert rows in `spng_encode_image`

### DIFF
--- a/spng/spng.c
+++ b/spng/spng.c
@@ -4761,6 +4761,13 @@ int spng_encode_image(spng_ctx *ctx, const void *img, size_t len, int fmt, int f
         if(len != ctx->image_size) return SPNG_EBUFSIZ;
     }
 
+    ssize_t row_stride = (ssize_t) ctx->image_width;
+    if(flags & SPNG_ENCODE_INVERT_ROWS)
+    {
+        img = (char const*) img + (ctx->ihdr.height - 1) * ctx->image_width;
+        row_stride = -row_stride;
+    }
+
     ret = spng_encode_chunks(ctx);
     if(ret) return encode_err(ctx, ret);
 
@@ -4864,7 +4871,7 @@ int spng_encode_image(spng_ctx *ctx, const void *img, size_t len, int fmt, int f
 
     do
     {
-        size_t ioffset = ri->row_num * ctx->image_width;
+        ssize_t ioffset = ri->row_num * row_stride;
 
         ret = encode_row(ctx, (unsigned char*)img + ioffset, ctx->image_width);
 

--- a/spng/spng.h
+++ b/spng/spng.h
@@ -216,6 +216,7 @@ enum spng_encode_flags
 {
     SPNG_ENCODE_PROGRESSIVE = 1, /* Initialize for progressive writes */
     SPNG_ENCODE_FINALIZE = 2, /* Finalize PNG after encoding image */
+    SPNG_ENCODE_INVERT_ROWS = 4, /* Interpret rows as being bottom-to-top */
 };
 
 struct spng_ihdr


### PR DESCRIPTION
This merge request is to share back something I implemented in a downstream copy of the project. No pressure to accept it; just sharing in case it's useful.

Previously, `spng_encode_image` would always interpret the `img` data pointer as pointing to image data in top-to-bottom order, despite some image data APIs storing image data in bottom-to-top order (most notably, OpenGL functions like `glReadPixels`).

This merge request adds a flag, `SPNG_ENCODE_INVERT_ROWS` to allow `spng_encode_image` to interpret the given image data pointer as containing rows in bottom-to-top order, instead of top-to-bottom. This allows saving PNG images directly from `glReadPixels` calls when using OpenGL, without an additional copy to reverse the row data.